### PR TITLE
Added callback usage on Scraper job errors

### DIFF
--- a/extension/scripts/Scraper.js
+++ b/extension/scripts/Scraper.js
@@ -90,7 +90,9 @@ Scraper.prototype = {
     job.execute(this.browser, function (err, job) {
       if (err) {
         // jobs don't seem to return anything
-        return console.error('Error in job', err)
+        this.executionCallback(err)
+        console.error('Error in job', err)
+        return
       }
       debug('finished executing')
       var scrapedRecords = []

--- a/extension/scripts/Scraper.js
+++ b/extension/scripts/Scraper.js
@@ -90,8 +90,8 @@ Scraper.prototype = {
     job.execute(this.browser, function (err, job) {
       if (err) {
         // jobs don't seem to return anything
-        this.executionCallback(err)
         console.error('Error in job', err)
+        this.executionCallback(err)
         return
       }
       debug('finished executing')

--- a/index.js
+++ b/index.js
@@ -54,7 +54,11 @@ function scrape (sitemapInfo, options = {}) {
       delay: options.delay || 500
     }, {})
     s.run(function (err) {
-      err ? reject(err) : resolve(store.data)
+      if (err) {
+        reject(err)
+      } else {
+        resolve(store.data)
+      }
     })
   })
 }

--- a/index.js
+++ b/index.js
@@ -53,9 +53,8 @@ function scrape (sitemapInfo, options = {}) {
       store,
       delay: options.delay || 500
     }, {})
-    s.run(function () {
-      // TODO there should be some error handling here
-      resolve(store.data)
+    s.run(function (err) {
+      err ? reject(err) : resolve(store.data)
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-scraper-headless",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Web Scraper Headless allows to extract data from web pages using plans (sitemaps) created with the Web Scraper browser extension. Using these sitemaps the  Web Scraper will navigate the site accordingly and extract all data. Scraped  data later can be exported as CSV.",
   "main": "index.js",
   "directories": {
@@ -63,7 +63,7 @@
     "karma-mocha": "^1.3.0",
     "mocha": "^3.2.0",
     "npm-watch": "^0.1.8",
-    "sinon": "^5.0.10",
+    "sinon": "^7.4.2",
     "standard": "^9.0.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
@@ -77,6 +77,6 @@
     "jquery": "^3.2.1",
     "jquery-deferred": "^0.3.1",
     "jsdom": "^10.1.0",
-    "puppeteer": "^1.4.0"
+    "puppeteer": "1.5.0"
   }
 }

--- a/tests/spec/ScraperSpec.js
+++ b/tests/spec/ScraperSpec.js
@@ -4,8 +4,10 @@ const assert = require('chai').assert
 const Sitemap = require('./../../extension/scripts/Sitemap')
 const FakeStore = require('./../FakeStore')
 const Scraper = require('./../../extension/scripts/Scraper')
+const Job = require('./../../extension/scripts/Job')
 const utils = require('./../utils')
 const globals = require('../globals')
+const sinon = require('sinon')
 
 describe('Scraper', function () {
   var q, store, $el
@@ -13,7 +15,7 @@ describe('Scraper', function () {
   let document
   let window
   let Browser
-
+  const sandbox = sinon.createSandbox()
   beforeEach(function () {
     $ = globals.$
     document = globals.document
@@ -27,6 +29,48 @@ describe('Scraper', function () {
   afterEach(function () {
     while (document.body.firstChild) document.body.removeChild(document.body.firstChild)
   })
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('Should handle error on job', function (done) {
+    sandbox.stub(Job.prototype, 'execute')
+      .callsFake(function (params, callback) {
+        callback(new Error('Fake error test'))
+      })
+    var b = document.querySelector('#scraper-test-one-page a')
+    console.log(b)
+    var sitemap = new Sitemap({
+      id: 'test',
+      startUrl: 'http://test.lv/',
+      selectors: [
+        {
+          'id': 'a',
+          'selector': '#scraper-test-one-page a',
+          'multiple': false,
+          type: 'SelectorText',
+          'parentSelectors': [
+            '_root'
+          ]
+        }
+      ]
+    }, {$, document, window})
+
+    var browser = new Browser({
+      pageLoadDelay: 100
+    })
+
+    var s = new Scraper({
+      queue: q,
+      sitemap: sitemap,
+      browser: browser,
+      store: store
+    }, {$, document, window})
+    s.run(function (err) {
+      err ? done() : done(new Error('Test should have failed')) 
+    })
+  })
+
 
   it('should be able to scrape one page', function (done) {
     var b = document.querySelector('#scraper-test-one-page a')
@@ -206,7 +250,6 @@ describe('Scraper', function () {
     var image = Scraper.prototype.getFileFilename('image.jpg')
     assert.equal(image, 'image.jpg')
   })
-
   // Not very clear what should jsdom do in this case
   it.skip('should store images', function (done) {
     var record = {

--- a/tests/spec/ScraperSpec.js
+++ b/tests/spec/ScraperSpec.js
@@ -10,7 +10,7 @@ const globals = require('../globals')
 const sinon = require('sinon')
 
 describe('Scraper', function () {
-  var q, store, $el
+  let q, store, $el
   let $
   let document
   let window
@@ -38,9 +38,9 @@ describe('Scraper', function () {
       .callsFake(function (params, callback) {
         callback(new Error('Fake error test'))
       })
-    var b = document.querySelector('#scraper-test-one-page a')
+    const b = document.querySelector('#scraper-test-one-page a')
     console.log(b)
-    var sitemap = new Sitemap({
+    const sitemap = new Sitemap({
       id: 'test',
       startUrl: 'http://test.lv/',
       selectors: [
@@ -56,18 +56,22 @@ describe('Scraper', function () {
       ]
     }, {$, document, window})
 
-    var browser = new Browser({
+    let browser = new Browser({
       pageLoadDelay: 100
     })
 
-    var s = new Scraper({
+    const s = new Scraper({
       queue: q,
       sitemap: sitemap,
       browser: browser,
       store: store
     }, {$, document, window})
     s.run(function (err) {
-      err ? done() : done(new Error('Test should have failed')) 
+      if (err) {
+        done()
+      } else {
+        done(new Error('Test should have failed')) 
+      }
     })
   })
 

--- a/tests/spec/ScraperSpec.js
+++ b/tests/spec/ScraperSpec.js
@@ -38,8 +38,7 @@ describe('Scraper', function () {
       .callsFake(function (params, callback) {
         callback(new Error('Fake error test'))
       })
-    const b = document.querySelector('#scraper-test-one-page a')
-    console.log(b)
+
     const sitemap = new Sitemap({
       id: 'test',
       startUrl: 'http://test.lv/',
@@ -77,8 +76,6 @@ describe('Scraper', function () {
 
 
   it('should be able to scrape one page', function (done) {
-    var b = document.querySelector('#scraper-test-one-page a')
-    console.log(b)
     var sitemap = new Sitemap({
       id: 'test',
       startUrl: 'http://test.lv/',


### PR DESCRIPTION
When a Job fails within a Scraper execution no callback was being called, causing an infinite wait loop